### PR TITLE
Add gitlab fully qualified domain name.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,12 +1,14 @@
 ---
 # General config.
-gitlab_external_url: "https://gitlab/"
+# fully qualified domain name: your.gitlab.domain.example.com
+gitlab_fqdn: gitlab
+gitlab_external_url: "https://{{ gitlab_fqdn }}/"
 gitlab_git_data_dir: "/var/opt/gitlab/git-data"
 
 # SSL Configuration.
 gitlab_redirect_http_to_https: "true"
-gitlab_ssl_certificate: "/etc/gitlab/ssl/gitlab.crt"
-gitlab_ssl_certificate_key: "/etc/gitlab/ssl/gitlab.key"
+gitlab_ssl_certificate: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.crt"
+gitlab_ssl_certificate_key: "/etc/gitlab/ssl/{{ gitlab_fqdn }}.key"
 
 # SSL Self-signed Certificate Configuration.
 gitlab_create_self_signed_cert: true


### PR DESCRIPTION
By defining the variable `gitlab_fqdn` it is easier to redefine
the variables:
- 'gitlab_external_url
- 'gitlab_ssl_certificate'
- 'gitlab_ssl_certificate_key'

Not only that. When using the Ansible role `gitlab` in conjunction
with `gitlab-runner`, this method allows to define:
- 'gitlab_runner_coordinator_url'
- 'gitlab_runner_tls_ca_file'

This way by over-writing one variable, it is possible to redefine
five variables in two roles, simplifying the `groups_vars/all` file
and the risk of making mistakes.
